### PR TITLE
Correct spelling of stable in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The application supports temporary privilege escalation via setuid/setgid bits. 
 
 ### setgid example on Debian
 
-On my Debian Stale 10 I have a group called `input` that has the access to `/dev/input/*` files. So this is what I do on my machine:
+On my Debian Stable 10 I have a group called `input` that has the access to `/dev/input/*` files. So this is what I do on my machine:
 
 ```
 # cp voidf /usr/local/bin


### PR DESCRIPTION
This changes "Debian Stale" to "Debian Stable". This might be an intentional joke about Debian, if that's the case I think it's funny.